### PR TITLE
implement jumping to addresses in a register

### DIFF
--- a/webassembliss/static/css/base_editor.css
+++ b/webassembliss/static/css/base_editor.css
@@ -166,3 +166,17 @@ td.memory-value-in-ascii {
     top: 0;
     z-index: 1;
 }
+
+/* Set the regName cells to relative so we can position items inside it */
+td[id^="regNameCell"] {
+    position: relative;
+    text-align: center;
+}
+
+/* Position scroll-to-memory icon on the right edge */
+td[id^="regNameCell"] .fa-memory {
+    position: absolute;
+    right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+}

--- a/webassembliss/static/js/base_editor.js
+++ b/webassembliss/static/js/base_editor.js
@@ -1153,6 +1153,46 @@ function toggleRowDisplay(rowID, type) {
     }
 }
 
+function addRegisterAddressLink(regName, regValue) {
+  // Add an event listener tying the regName and regValue together
+  regName.addEventListener("click", () => {
+    // Get the address in the regValue element
+    let address_unparsed = regValue.innerHTML;
+
+    // Parse it to be the representation we need
+    let address = address_unparsed.replaceAll("&nbsp;", "").replace(/^0*/,"").toLowerCase();
+    let memcell_format =  address.substring(0, address.length - 1) + "0+" + address.slice(-1)
+
+    // And try to retrieve the memory cell referenced by the instruction
+    let memcell = document.getElementById(`memValueCell-${memcell_format}`);
+
+    // If it is a memory address
+    if (memcell !== null) {
+      // Move it into view
+      memcell.scrollIntoView(
+        {
+          block: 'nearest',
+          inline: 'center',
+        }
+      );
+
+      // And make it noticeable
+      memcell.animate(
+        [
+          { transform: 'scale(1)' },
+          { transform: `scale(2)` },
+          { transform: 'scale(1)' }
+        ],
+        {
+          duration: 500,
+          easing: 'ease-in-out',
+          iterations: 1
+        }
+      );
+    }
+  })
+}
+
 function populateRegisterTable(registers) {
     // Create a starting values with enough zeros for the number of bits given.
     let starting_value = intToHexBytes(0, ARCH_NUM_BITS / 8, "&nbsp;&nbsp;");
@@ -1174,6 +1214,10 @@ function populateRegisterTable(registers) {
         // Assign the appropriate values.
         regName.innerHTML = `<input class="form-check-input register-display-check" type="checkbox" value="" id="${newTr.id}-check" onclick='toggleRowDisplay("${newTr.id}", "register")' hidden checked> ${reg}`;
         regValue.innerHTML = starting_value;
+
+        // add an onclick event to go to the address inside the register.
+        addRegisterAddressLink(regName, regValue);
+
         // Add the new cells to our new row.
         newTr.appendChild(regName);
         newTr.appendChild(regValue);

--- a/webassembliss/static/js/base_editor.js
+++ b/webassembliss/static/js/base_editor.js
@@ -1172,7 +1172,7 @@ function scrollToMemoryAddress(address) {
         // Move it into view
         memcell.scrollIntoView(
             {
-                block: 'nearest',
+                block: 'center',
                 inline: 'center',
             }
         );

--- a/webassembliss/templates/about.html.j2
+++ b/webassembliss/templates/about.html.j2
@@ -22,6 +22,8 @@
         Harrison&nbsp;Blough, Logan&nbsp;Crisp, Trevor&nbsp;Harless, Daniel&nbsp;Schimtzek,
         {# S' 25 #}
         Sam&nbsp;Smithers, Samuel&nbsp;Fishburn.
+        {# S' 26 #}
+        Alice&nbsp;Stauffer
       </p>
     </div>
   </div>

--- a/webassembliss/templates/about.html.j2
+++ b/webassembliss/templates/about.html.j2
@@ -21,9 +21,9 @@
         {# F' 24 #}
         Harrison&nbsp;Blough, Logan&nbsp;Crisp, Trevor&nbsp;Harless, Daniel&nbsp;Schimtzek,
         {# S' 25 #}
-        Sam&nbsp;Smithers, Samuel&nbsp;Fishburn.
+        Sam&nbsp;Smithers, Samuel&nbsp;Fishburn,
         {# S' 26 #}
-        Alice&nbsp;Stauffer
+        Alice&nbsp;Stauffer.
       </p>
     </div>
   </div>


### PR DESCRIPTION
This should make tricks that rely on large memory spaces (or just larger programs) a lot easier to use.  I've done some minimal testing just running this patched in the live instance. It doesn't gracefully handle an address that doesn't appear inside the address block, I.e. an address that points to a `.space` directive.

I chose to implement it while making the register table so there wasn't a bunch of creation and deletion of event handlers. I'm not super familiar with javascript performance implications but that doesn't sound great.

It'd be nice to have this functionality exist with some sort of nicer warning when an address doesn't exist, but I don't really have a vision for that yet. The scale transformation also feels a little out of place, but handling color state wasn't something I wanted to do at the moment.

fixes #4 